### PR TITLE
Option: Customize selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,31 +33,6 @@ To check the layout change, in your HTML file, add attribute in your html tags
 
 Or, in your js file, set `document.dir = 'rtl'` or `document.dir = 'ltr'`.
 
-## Options
-
-postcss-bidirection accepts an options object.
-
-```
-const plugin = require('postcss-bidirection');
-const opts = {
-    ...
-};
-postcss([ plugin(opts) ]).process(input) ...
-```
-
-### Custom Selectors
-
-By default, postcss-bidirection will prefix generated selectors with `html[dir="rtl"]` or `html[dir="ltr"]`.
-The `buildSelector` option allows you to customize this behavior. For example, to drop `html` from generated selectors, pass a custom `buildSelector` function to the plugin:
-
-```
-const opts = {
-  buildSelector = function(selector, direction) {
-    return '[dir=" + direction + '"] ' + selector;
-  }
-};
-```
-
 ## Examples
 
 PostCSS Bidirection support syntax based on https://wiki.mozilla.org/Gaia/CSS_Guidelines
@@ -182,6 +157,61 @@ All supported syntax are listed below
 |                 **absolute positioning**                       |
 | left                       | offset-inline-start               |
 | right                      | offset-inline-end                 |
+
+## Options
+
+postcss-bidirection accepts an options object.
+
+```
+const plugin = require('postcss-bidirection');
+const opts = {
+    ...
+};
+postcss([ plugin(opts) ]).process(input) ...
+```
+
+### Custom Selectors
+
+By default, postcss-bidirection prefixes generated CSS selectors with `html[dir="rtl"]` or `html[dir="ltr"]`. The `buildSelector` option allows you to override this behavior. 
+
+This callback gets called once for every selector of every rule that contains translated properties. If the rule has multiple selectors separated by commas, then it will be called multiple times for that rule.
+
+It takes two arguments:
+  - the original CSS selector of the rule that we are translating
+  - The direction to which it is being translated. Can be `rtl` or `ltr`.
+  
+It should return a CSS selector string, which will be attached to the translated CSS rule.
+   
+For example, to drop `html` from generated selectors, pass a custom `buildSelector` function to the plugin.
+
+```
+const opts = {
+  buildSelector = function(selector, direction) {
+    return '[dir=" + direction + '"] ' + selector;
+  }
+};
+
+postcss([ require('postcss-bidirection')(opts) ])
+```
+
+Input
+
+```css
+.foo {
+  text-align: start;
+}
+```
+
+Now we have `[dir="rtl"]` instead of `html[dir="rtl"]` in the output: 
+
+```css
+.foo {
+  text-align: left;
+}
+
+[dir="rtl"] .foo {
+  text-align: right;
+}
 
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ To check the layout change, in your HTML file, add attribute in your html tags
 
 Or, in your js file, set `document.dir = 'rtl'` or `document.dir = 'ltr'`.
 
+## Options
+
+postcss-bidirection accepts an options object.
+
+```
+const plugin = require('postcss-bidirection');
+const opts = {
+    ...
+};
+postcss([ plugin(opts) ]).process(input) ...
+```
+
+### Custom Selectors
+
+By default, postcss-bidirection will prefix generated selectors with `html[dir="rtl"]` or `html[dir="ltr"]`.
+The `buildSelector` option allows you to customize this behavior. For example, to drop `html` from generated selectors, pass a custom `buildSelector` function to the plugin:
+
+```
+const opts = {
+  buildSelector = function(selector, direction) {
+    return '[dir=" + direction + '"] ' + selector;
+  }
+};
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Now we have `[dir="rtl"]` instead of `html[dir="rtl"]` in the output:
 [dir="rtl"] .foo {
   text-align: right;
 }
-
+```
 
 ## Debugging
 

--- a/index.js
+++ b/index.js
@@ -151,11 +151,20 @@ function updateLtrItem(item) {
     return updateRtlItem(item, true);
 }
 
+// Return directional CSS selector (eg: "html[dir='ltr'] .footer") based on original selector and direction (rtl/ltr)
+// This can be overriden in options
+function defaultBuildSelector(selector, direction) {
+    return('html[dir="' + direction + '"] ' + selector);
+}
+
 function postcssBiDirection(opts) {
     opts = opts || {};
     const PATTERN = /\s*[,\n]+\s*/;
 
     // Work with options here
+    if(!opts.buildSelector) {
+        opts.buildSelector = defaultBuildSelector;
+    }
 
     return function (root) {
         let tree = [];
@@ -208,8 +217,8 @@ function postcssBiDirection(opts) {
                 // prefix each comma-separated selector
                 item.ltrRule.selector = item.ltrRule.selector
                     .split(PATTERN)
-                    .map(function(selector, i) {
-                        return ("html[dir=\"ltr\"] " + selector);
+                    .map(function(selector, i){
+                        return opts.buildSelector(selector, 'ltr');
                     })
                     .join(',\n');
 
@@ -222,8 +231,8 @@ function postcssBiDirection(opts) {
                 // prefix each comma-separated selector
                 item.rtlRule.selector = item.rtlRule.selector
                     .split(PATTERN)
-                    .map(function(selector, i) {
-                        return ("html[dir=\"rtl\"] " + selector);
+                    .map(function(selector, i){
+                        return opts.buildSelector(selector, 'rtl');
                     })
                     .join(',\n');
 

--- a/tests/fixtures/custom-selector-input.css
+++ b/tests/fixtures/custom-selector-input.css
@@ -1,0 +1,3 @@
+.foo{
+    offset-inline-start: 1px;    
+}

--- a/tests/fixtures/custom-selector-output.css
+++ b/tests/fixtures/custom-selector-output.css
@@ -1,0 +1,11 @@
+.foo{
+    offset-inline-start: 1px;    
+}
+
+.bar.direction-ltr .foo{
+    left: 1px;    
+}
+
+[dir="rtl"] .foo{
+    right: 1px;    
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -126,3 +126,16 @@ test('nested rules', t => {
     const { input, output } = read('nested');
     return run(t, input, output, { });
 });
+
+test('custom selector', t => {
+    const { input, output } = read('custom-selector');
+    return run(t, input, output, {
+        buildSelector: function(selector, direction) {
+            if(direction == "ltr") {
+                return ".bar.direction-ltr " + selector;
+            } else {
+                return '[dir="' + direction + '"] ' + selector;
+            }
+        }
+    });
+});


### PR DESCRIPTION
- Added function `defaultBuildSelector`
- Added options `buildSelector` to override `defaultBuildSelector`
- Added section **Options** in Readme
- Added tests and fixtures `custom-selector-(input|output)`

This is in reference to issue https://github.com/gasolin/postcss-bidirection/issues/7

I tried to follow your spacing convention!

Note: I cherry picked from my master branch, which is running a newer version of ava (tests succeed). I haven't run the tests with the older version of ava, I'm assuming they would pass.