### PR TITLE
rename offset-* to inset-*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.7 2018/08/24
+
+* support renamed inset-inline-(start/end) properties
+
 2.6 2017/11/23
 
 * support custom output via pass the `buildSelector` option, thanks @rolfen

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Input
 
 ```css
 .foo {
-  offset-inline-start: 1px;
+  inset-inline-start: 1px;
 }
 ```
 
@@ -155,6 +155,8 @@ All supported syntax are listed below
 | margin-left                | margin-inline-start               |
 | margin-right               | margin-inline-end                 |
 |                 **absolute positioning**                       |
+| left                       | inset-inline-start                |
+| right                      | inset-inline-end                  |
 | left                       | offset-inline-start               |
 | right                      | offset-inline-end                 |
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const SUPPORT_PROPS = ['float', 'clear', 'text-align', 'padding-inline-start', '
     'border-top-inline-start-radius', 'border-top-inline-end-radius',
     'border-bottom-inline-start-radius', 'border-bottom-inline-end-radius',
     'margin-inline-start', 'margin-inline-end',
-    'offset-inline-start', 'offset-inline-end'
+    'offset-inline-start', 'offset-inline-end',
+    'inset-inline-start', 'inset-inline-end'
 ];
 
 function log(...args) {
@@ -91,9 +92,11 @@ function processProps(decl, reverseFlag) {
     case 'margin-inline-end':
         decl.prop = 'margin-' + end;
         break;
+    case 'inset-inline-start':
     case 'offset-inline-start':
         decl.prop = start;
         break;
+    case 'inset-inline-end':
     case 'offset-inline-end':
         decl.prop = end;
         break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-bidirection",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "PostCSS plugin that polyfill Mozilla's Bi-directional CSS proposal to suppot direction-sensitive rules, a.k.a Left-To-Right (LTR) and Right-To-Left (RTL), in single syntax",
   "keywords": [
     "postcss",

--- a/sample.css
+++ b/sample.css
@@ -53,3 +53,11 @@
 .foo {
   offset-inline-end: 1px;
 }
+
+.foo {
+  inset-inline-start: 1px;
+}
+
+.foo {
+  inset-inline-end: 1px;
+}

--- a/tests/fixtures/inset-inline-input.css
+++ b/tests/fixtures/inset-inline-input.css
@@ -1,0 +1,7 @@
+.foo {
+  inset-inline-start: 1px;
+}
+
+.bar {
+  inset-inline-end: 1px;
+}

--- a/tests/fixtures/inset-inline-output.css
+++ b/tests/fixtures/inset-inline-output.css
@@ -1,0 +1,23 @@
+.foo {
+  inset-inline-start: 1px;
+}
+
+html[dir="ltr"] .foo {
+  left: 1px;
+}
+
+html[dir="rtl"] .foo {
+  right: 1px;
+}
+
+.bar {
+  inset-inline-end: 1px;
+}
+
+html[dir="ltr"] .bar {
+  right: 1px;
+}
+
+html[dir="rtl"] .bar {
+  left: 1px;
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -135,9 +135,9 @@ test('nested rules', t => {
 test('custom selector', t => {
     const { input, output } = read('custom-selector');
     return run(t, input, output, {
-        buildSelector: function(selector, direction) {
-            if(direction == "ltr") {
-                return ".bar.direction-ltr " + selector;
+        buildSelector: function (selector, direction) {
+            if(direction === 'ltr') {
+                return '.bar.direction-ltr ' + selector;
             } else {
                 return '[dir="' + direction + '"] ' + selector;
             }

--- a/tests/test.js
+++ b/tests/test.js
@@ -90,6 +90,11 @@ test('offset-inline-(start/end)', t => {
     return run(t, input, output, { });
 });
 
+test('inset-inline-(start/end)', t => {
+    const { input, output } = read('inset-inline');
+    return run(t, input, output, { });
+});
+
 test('do not do anything on unaffected rules', t => {
     var input = `.foo {
   margin-top: 1px


### PR DESCRIPTION
This is implementation of issue #18 

I was not sure if we want to rename or add support for inset-inline properties. They get renamed in spec but if there's a code that is using this package than we might break it with this change. @gasolin let me know what do you think about it.

I let myself bump a version. Please check if it matches the versioning in this project.