### PR TITLE
Replace CRLF with LF when loading fixtures

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -8,7 +8,7 @@ function read(name) {
     function _read(ele) {
         return fs.readFileSync(`./tests/fixtures/${ele}.css`, {
             encoding: 'utf8'
-        });
+        }).replace(/\r\n/g, '\n');
     }
     const input = _read(`${name}-input`);
     const output = _read(`${name}-output`);


### PR DESCRIPTION
Not sure if this is the best way to do it, but otherwise fixtures wouldn't run on my machine. Git on Windows by default transforms LFs to CRLFs, which makes most tests fail.